### PR TITLE
added missing deliveryAvailable field

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -82,6 +82,7 @@ const UserSchema = new mongoose.Schema({
   ],
 
   wholesaleAvailable: { type: Boolean, default: false },
+  deliveryAvailable: { type: Boolean, default: false },
   followers: [{type: mongoose.Schema.Types.ObjectId, ref: 'User'}],
   following: [{type: mongoose.Schema.Types.ObjectId, ref: 'User'}],
 


### PR DESCRIPTION
user data sent to the frontend contains "wholesaleAvailable" but no "deliveryAvailable" data point when it is logged to the browser console. Upon closer inspection, backend user schema is missing "deliveryAvailable". 

This might explain why only wholesaleAvailable can be updated and its information retained reliably on the frontend, but not deliveryAvailable.
